### PR TITLE
feat: add a find downloads command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e69600ff1703123957937708eb27f7a564e48885c537782722ed0ba3189ce1d7"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "edmgutil"
 version = "0.1.0"
 dependencies = [
@@ -86,11 +106,14 @@ dependencies = [
  "chrono",
  "clap",
  "dialoguer",
+ "directories",
  "plist",
  "serde",
  "structopt",
+ "url",
  "uuid",
  "which",
+ "xattr",
 ]
 
 [[package]]
@@ -104,6 +127,16 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "getrandom"
@@ -129,6 +162,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -163,6 +207,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +230,12 @@ checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "plist"
@@ -290,6 +346,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -411,6 +477,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ac2e1d4bd0f75279cfd5a076e0d578bbf02c22b7c39e766c437dd49b3ec43e0"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
+dependencies = [
+ "matches",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +526,19 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+ "serde",
+]
 
 [[package]]
 name = "uuid"
@@ -480,6 +592,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "xattr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ serde = { version = "1.0.126", features = ["derive"] }
 structopt = { version = "0.3.21", default-features = false }
 clap = { version = "2.33.3", default-features = false }
 chrono = { version = "0.4.19", default-features = false, features = ["std"] }
+xattr = "0.2.2"
+directories = "3.0.2"
+url = { version = "2.2.2", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -77,3 +77,22 @@ which runs ejecting hourly:
 ```
 edmgutil cron --install
 ```
+
+## Download Folder Monitoring
+
+Because browsers love to download files unprompted into the default download location it's not
+uncommon for you to accidentally places files there you really don't want to retain there.
+The `find-downloads` command can be useful for manual spot checking.
+
+This will list all files that were downloaded from `your-domain.tld`:
+
+```
+edmgutil find-downloads -d your-domain.tld
+```
+
+For additional information you can turn on verbose mode which shows the exact source of the
+file by URL:
+
+```
+edmgutil find-downloads -d your-domain.tld -v
+```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,7 @@ pub enum Commands {
     List(ListCommand),
     Eject(EjectCommand),
     Cron(CronCommand),
+    FindDownloads(FindDownloadsCommand),
 }
 
 #[derive(Debug, StructOpt)]
@@ -93,4 +94,23 @@ pub struct CronCommand {
     /// uninstalls the cron
     #[structopt(long = "uninstall")]
     pub uninstall: bool,
+}
+
+/// helps monitoring the download folder for problematic sources
+///
+/// This command lets you quickly show all the files in your downloads folder
+/// which come from a specific source.  This way you can easily periodically
+/// check that it does not contain files you don't expect it to be there.
+#[derive(Debug, StructOpt)]
+#[structopt(setting(AppSettings::ArgRequiredElseHelp))]
+pub struct FindDownloadsCommand {
+    /// the domains to look out for
+    #[structopt(long = "domain", short = "d")]
+    pub domains: Vec<String>,
+    /// list found files
+    #[structopt(long = "list", short = "l")]
+    pub list: bool,
+    /// provide additional information when listing files
+    #[structopt(long = "verbose", short = "v")]
+    pub verbose: bool,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -102,15 +102,13 @@ pub struct CronCommand {
 /// which come from a specific source.  This way you can easily periodically
 /// check that it does not contain files you don't expect it to be there.
 #[derive(Debug, StructOpt)]
-#[structopt(setting(AppSettings::ArgRequiredElseHelp))]
 pub struct FindDownloadsCommand {
     /// the domains to look out for
     #[structopt(long = "domain", short = "d")]
     pub domains: Vec<String>,
-    /// list found files
-    #[structopt(long = "list", short = "l")]
-    pub list: bool,
     /// provide additional information when listing files
     #[structopt(long = "verbose", short = "v")]
     pub verbose: bool,
+    /// an alternative folder than the default download folder to search
+    pub path: Option<PathBuf>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,10 +162,13 @@ fn cron_command(args: CronCommand) -> Result<(), Error> {
 
 fn find_downloads_command(args: FindDownloadsCommand) -> Result<(), Error> {
     let dirs = directories::UserDirs::new();
-    let download_dir = dirs
-        .as_ref()
-        .and_then(|x| x.download_dir())
-        .ok_or_else(|| anyhow!("could not find download dir"))?;
+    let download_dir = match args.path {
+        Some(ref path) => path.as_path(),
+        None => dirs
+            .as_ref()
+            .and_then(|x| x.download_dir())
+            .ok_or_else(|| anyhow!("could not find download dir"))?,
+    };
 
     let mut matches = vec![];
 


### PR DESCRIPTION
This adds a command to manually check the downloads folder for accidentally placed files.

Because browsers love to download files unprompted into the default download location it's not
uncommon for you to accidentally places files there you really don't want to retain there.
The `find-downloads` command can be useful for manual spot checking.